### PR TITLE
Add action to format whole file

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,8 +40,8 @@
 
   <actions>
     <action id="ClangFormat.ClangFormat" class="io.probst.idea.clangformat.ClangFormatAction"
-            text="clang-format"
-            description="Runs clang-format on this buffer">
+            text="clang-format selection"
+            description="Runs clang-format on the current statement or selection">
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
 
       <keyboard-shortcut keymap="Mac OS X" first-keystroke="control alt K"/>
@@ -50,7 +50,11 @@
     </action>
     <action id="ClangFormat.ClangFormatFile" class="io.probst.idea.clangformat.ClangFormatFileAction"
             text="clang-format file"
-            description="Runs clang-format on current file">
+            description="Runs clang-format on the current file">
+    </action>
+    <action id="ClangFormat.ClangFormatAuto" class="io.probst.idea.clangformat.ClangFormatAutoAction"
+            text="clang-format file or selection"
+            description="Runs clang-format on the current file or selection">
     </action>
   </actions>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,7 +40,7 @@
 
   <actions>
     <action id="ClangFormat.ClangFormat" class="io.probst.idea.clangformat.ClangFormatAction"
-            text="clang-format selection"
+            text="Reformat Current Statement with clang-format"
             description="Runs clang-format on the current statement or selection">
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
 
@@ -49,12 +49,13 @@
       <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt K"/>
     </action>
     <action id="ClangFormat.ClangFormatFile" class="io.probst.idea.clangformat.ClangFormatFileAction"
-            text="clang-format file"
+            text="Reformat File with clang-format"
             description="Runs clang-format on the current file">
     </action>
     <action id="ClangFormat.ClangFormatAuto" class="io.probst.idea.clangformat.ClangFormatAutoAction"
-            text="clang-format file or selection"
+            text="Reformat Code with clang-format"
             description="Runs clang-format on the current file or selection">
+      <add-to-group group-id="CodeFormatGroup" anchor="after" relative-to-action="ReformatCode"/>
     </action>
   </actions>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -48,6 +48,10 @@
       <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt K"/>
       <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt K"/>
     </action>
+    <action id="ClangFormat.ClangFormatFile" class="io.probst.idea.clangformat.ClangFormatFileAction"
+            text="clang-format file"
+            description="Runs clang-format on current file">
+    </action>
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/io/probst/idea/clangformat/ClangFormatAction.java
+++ b/src/io/probst/idea/clangformat/ClangFormatAction.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -166,9 +167,8 @@ public class ClangFormatAction extends AnAction {
       int selectionLength) throws ExecutionException, InterruptedException {
     Settings settings = Settings.get();
 
-    ProcessBuilder command = new ProcessBuilder().command(settings.clangFormatBinary, "-style=file",
-        "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor,
-        "-offset=" + selectionStart, "-length=" + selectionLength);
+    ProcessBuilder command = new ProcessBuilder().command(
+            getCommandArguments(settings.clangFormatBinary, filePath, cursor, selectionStart, selectionLength));
 
     if (settings.path != null) {
       command.environment().put("PATH", settings.path);
@@ -188,6 +188,17 @@ public class ClangFormatAction extends AnAction {
       }
     }
     return command;
+  }
+
+  /**
+   * Builds a list of arguments to clang-format
+   */
+  protected List<String> getCommandArguments(String clangFormatBinary, String filePath, int cursor, int selectionStart,
+                                             int selectionLength) {
+    return Arrays.asList(clangFormatBinary, "-style=file",
+            "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor,
+            "-offset=" + selectionStart, "-length=" + selectionLength);
+
   }
 
   private void writeFileContents(Document document, OutputStream outputStream) {

--- a/src/io/probst/idea/clangformat/ClangFormatAutoAction.java
+++ b/src/io/probst/idea/clangformat/ClangFormatAutoAction.java
@@ -1,0 +1,26 @@
+package io.probst.idea.clangformat;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Runs clang-format on the current selection or on the whole file if there is no selection.
+ * Applies the formatting updates to the editor.
+ */
+public class ClangFormatAutoAction extends ClangFormatAction {
+    /**
+     * Builds a list of arguments to clang-format
+     */
+    @Override
+    protected List<String> getCommandArguments(String clangFormatBinary, String filePath, int cursor, int selectionStart,
+                                               int selectionLength) {
+        if (selectionLength > 0) {
+            // Format the selection as normal
+            return super.getCommandArguments(clangFormatBinary, filePath, cursor, selectionStart, selectionLength);
+        } else {
+            // Format the whole file
+            return Arrays.asList(clangFormatBinary, "-style=file",
+                    "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor);
+        }
+    }
+}

--- a/src/io/probst/idea/clangformat/ClangFormatFileAction.java
+++ b/src/io/probst/idea/clangformat/ClangFormatFileAction.java
@@ -1,0 +1,21 @@
+package io.probst.idea.clangformat;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Runs clang-format on the whole file, and applies the formatting updates to the editor.
+ */
+public class ClangFormatFileAction extends ClangFormatAction {
+  /**
+   * Builds a list of arguments to clang-format
+   *
+   * To format the whole file, we ignore the selection arguments.
+   */
+  @Override
+  protected List<String> getCommandArguments(String clangFormatBinary, String filePath, int cursor, int selectionStart,
+                                             int selectionLength) {
+    return Arrays.asList(clangFormatBinary, "-style=file",
+            "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor);
+  }
+}


### PR DESCRIPTION
Resolves #5 

The current `ClangFormatAction` formats either the current statement or the current selection. This PR adds two new actions:
  - `ClangFormatFileAction`: Format the whole file
  - `ClangFormatAutoAction`: Format the whole file or current selection, if there is one

Also adds `ClangFormatAutoAction` action to the "Code" menu under the built-in "Reformat Code". (I think that one fits in the menu since its behaviour is the same as "Reformat Code"). Changes the action `text` to be consistent with built-in actions.
