### PR TITLE
Add feature for formatting only VCS changed text

### DIFF
--- a/src/io/probst/idea/clangformat/ClangFormatAutoAction.java
+++ b/src/io/probst/idea/clangformat/ClangFormatAutoAction.java
@@ -1,26 +1,80 @@
 package io.probst.idea.clangformat;
 
-import java.util.Arrays;
-import java.util.List;
+import com.intellij.codeInsight.actions.FormatChangedTextUtil;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.codeStyle.ChangedRangesInfo;
+import com.intellij.util.diff.FilesTooBigForDiffException;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Runs clang-format on the current selection or on the whole file if there is no selection.
  * Applies the formatting updates to the editor.
  */
 public class ClangFormatAutoAction extends ClangFormatAction {
-    /**
-     * Builds a list of arguments to clang-format
-     */
+
+    private Collection<TextRange> getVcsTextRanges(Project project, VirtualFile virtualFile) {
+        final PsiManager myPsiManager = PsiManager.getInstance(project);
+        PsiFile psiFile = myPsiManager.findFile(virtualFile);
+        try {
+            FormatChangedTextUtil textUtil = FormatChangedTextUtil.getInstance();
+
+            // Check if the file is under VCS. If it is not then we just use the standard code
+            if (!textUtil.isChangeNotTrackedForFile(project, psiFile)) {
+                ChangedRangesInfo changedRangesInfo = textUtil.getChangedRangesInfo(psiFile);
+
+                // null can be returned if there are no changes
+                if (changedRangesInfo != null) {
+                    return changedRangesInfo.allChangedRanges;
+                }
+                return Collections.emptyList();
+            }
+        } catch (FilesTooBigForDiffException e) {
+            // Ignore and let the standard case handle this. If a file is too big to diff then a full reformat should
+            // probably be fine
+        }
+        return null;
+    }
+
     @Override
-    protected List<String> getCommandArguments(String clangFormatBinary, String filePath, int cursor, int selectionStart,
-                                               int selectionLength) {
-        if (selectionLength > 0) {
-            // Format the selection as normal
-            return super.getCommandArguments(clangFormatBinary, filePath, cursor, selectionStart, selectionLength);
+    protected Collection<TextRange> getFormatRanges(Project project,
+                                                    Document document,
+                                                    Editor editor,
+                                                    VirtualFile virtualFile) {
+        Settings settings = Settings.get();
+
+        // IntelliJ reports a cursor at the end of the file as being at file length + 1, which breaks
+        // clang-format.
+        int docLength = document.getTextLength() - 1;
+        int selectionStart = Math.min(editor.getSelectionModel().getSelectionStart(), docLength);
+        int selectionLength = Math.min(editor.getSelectionModel().getSelectionEnd(), docLength) - selectionStart;
+
+        // Formatting the VCS changed text will only be done if nothing is selected. Otherwise you can't force a reformat
+        // of some code that was not changed from the VCS version
+        if (selectionLength <= 0 && settings.updateOnlyChangedText) {
+            // This case only formats the text changed in the VCS. If the diff is too large or we are not in a VCS file
+            // then the standard behavior will be used (selection or whole file)
+            Collection<TextRange> vcsRanges = getVcsTextRanges(project, virtualFile);
+
+            // getVcsTextRanges returns null if it could return any valid ranges in which case we
+            // will use the non-VCS branch
+            if (vcsRanges != null) {
+                // The VCS has returned some ranges to format
+                return vcsRanges;
+            }
+        }
+
+        if (selectionLength <= 0) {
+            return Collections.singletonList(new TextRange(0, docLength));
         } else {
-            // Format the whole file
-            return Arrays.asList(clangFormatBinary, "-style=file",
-                    "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor);
+            return Collections.singletonList(new TextRange(selectionStart, selectionStart + selectionLength));
         }
     }
 }

--- a/src/io/probst/idea/clangformat/ClangFormatConfigurable.java
+++ b/src/io/probst/idea/clangformat/ClangFormatConfigurable.java
@@ -5,7 +5,10 @@ import com.intellij.openapi.options.ConfigurationException;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
 import java.util.Objects;
 
 /**
@@ -17,6 +20,7 @@ public class ClangFormatConfigurable implements Configurable {
   private JTextField clangFormatBinary;
   private JTextField path;
   private JPanel configurationForm;
+  private JCheckBox formatOnlyChangedTextCheckBox;
 
   @Nls
   @Override
@@ -40,18 +44,20 @@ public class ClangFormatConfigurable implements Configurable {
   @Override
   public boolean isModified() {
     return !Objects.equals(settings.clangFormatBinary, clangFormatBinary.getText())
-        || !Objects.equals(settings.path, path.getText());
+        || !Objects.equals(settings.path, path.getText())
+        || !Objects.equals(settings.updateOnlyChangedText, formatOnlyChangedTextCheckBox.isSelected());
   }
 
   @Override
   public void apply() throws ConfigurationException {
-    settings = Settings.update(clangFormatBinary.getText(), path.getText());
+    settings = Settings.update(clangFormatBinary.getText(), path.getText(), formatOnlyChangedTextCheckBox.isSelected());
   }
 
   @Override
   public void reset() {
     clangFormatBinary.setText(settings.clangFormatBinary);
     path.setText(settings.path);
+    formatOnlyChangedTextCheckBox.setSelected(settings.updateOnlyChangedText);
   }
 
   @Override

--- a/src/io/probst/idea/clangformat/ClangFormatFileAction.java
+++ b/src/io/probst/idea/clangformat/ClangFormatFileAction.java
@@ -1,21 +1,24 @@
 package io.probst.idea.clangformat;
 
-import java.util.Arrays;
-import java.util.List;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Runs clang-format on the whole file, and applies the formatting updates to the editor.
  */
 public class ClangFormatFileAction extends ClangFormatAction {
-  /**
-   * Builds a list of arguments to clang-format
-   *
-   * To format the whole file, we ignore the selection arguments.
-   */
   @Override
-  protected List<String> getCommandArguments(String clangFormatBinary, String filePath, int cursor, int selectionStart,
-                                             int selectionLength) {
-    return Arrays.asList(clangFormatBinary, "-style=file",
-            "-output-replacements-xml", "-assume-filename=" + filePath, "-cursor=" + cursor);
+  protected Collection<TextRange> getFormatRanges(Project project, Document document, Editor editor, VirtualFile virtualFile) {
+    // IntelliJ reports a cursor at the end of the file as being at file length + 1, which breaks
+    // clang-format.
+    int docLength = document.getTextLength() - 1;
+
+    return Collections.singletonList(new TextRange(0, docLength));
   }
 }

--- a/src/io/probst/idea/clangformat/ConfigurationForm.form
+++ b/src/io/probst/idea/clangformat/ConfigurationForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.probst.idea.clangformat.ClangFormatConfigurable">
-  <grid id="27dc6" binding="configurationForm" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="configurationForm" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="491" height="388"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="36eff">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="5b6ac" class="javax.swing.JLabel">
@@ -57,6 +57,14 @@
         </constraints>
         <properties>
           <columns value="1"/>
+        </properties>
+      </component>
+      <component id="230f5" class="javax.swing.JCheckBox" binding="formatOnlyChangedTextCheckBox" default-binding="true">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Format only changed text"/>
         </properties>
       </component>
     </children>

--- a/src/io/probst/idea/clangformat/Settings.java
+++ b/src/io/probst/idea/clangformat/Settings.java
@@ -6,15 +6,17 @@ import com.intellij.ide.util.PropertiesComponent;
 public class Settings {
   private static final String CF_BINARY_PROP = ClangFormatConfigurable.class.getName() + ".clangFormatBinary";
   private static final String CF_PATH_PROP = ClangFormatConfigurable.class.getName() + ".path";
+  private static final String CF_VCS_FORMAT_PROP = ClangFormatConfigurable.class.getName() + ".vcs_format";
 
   final String clangFormatBinary;
   final String path;
+  final boolean updateOnlyChangedText;
 
   static Settings get() {
     return new Settings();
   }
 
-  static Settings update(String clangFormatBinary, String path) {
+  static Settings update(String clangFormatBinary, String path, boolean updateOnlyChangedText) {
     if ("".equals(clangFormatBinary)) {
       clangFormatBinary = "clang-format";
     }
@@ -24,6 +26,7 @@ public class Settings {
     PropertiesComponent props = PropertiesComponent.getInstance();
     props.setValue(CF_BINARY_PROP, clangFormatBinary, "clang-format");
     props.setValue(CF_PATH_PROP, path, null);
+    props.setValue(CF_VCS_FORMAT_PROP, updateOnlyChangedText);
     return get();
   }
 
@@ -31,5 +34,6 @@ public class Settings {
     PropertiesComponent props = PropertiesComponent.getInstance();
     clangFormatBinary = props.getValue(CF_BINARY_PROP, "clang-format");
     path = props.getValue(CF_PATH_PROP);
+    updateOnlyChangedText = props.getBoolean(CF_VCS_FORMAT_PROP, false);
   }
 }


### PR DESCRIPTION
This is similar to what is available in the built-in format action. It
can be enabled using a check box in the settings which is disabled by
default.